### PR TITLE
Change the go.image subrepo import path

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -12,8 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"code.google.com/p/go.image/bmp"
-	"code.google.com/p/go.image/tiff"
+	"golang.org/x/image/bmp"
+	"golang.org/x/image/tiff"
 )
 
 // Open loads an image from file


### PR DESCRIPTION
Based on
https://groups.google.com/forum/#!msg/golang-nuts/eD8dh3T9yyA/l5Ail-xfMiAJ
all of the code.google.com/p/go.\* subrepos are getting moved to
golang.org/x/\* this commit points the
`code.google.com/p/go.image/tiff` to `golang.org/x/image`
