### PR TITLE
add DecodeWithFormat function

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -90,6 +90,12 @@ func Decode(r io.Reader) (image.Image, error) {
 	return img, err
 }
 
+// DecodeWithFormat reads an image from r and returns the format of the image: jpeg, png, giff.
+// It sniffs the header of the image contents to get the type. FormatFromFilename is an alternative that obtains the format based on the file extension.
+func DecodeWithFormat(r io.Reader) (image.Image, string, error) {
+	return image.Decode(r)
+}
+
 // Open loads an image from file
 func Open(filename string) (image.Image, error) {
 	file, err := fs.Open(filename)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -147,6 +147,12 @@ func TestOpenSave(t *testing.T) {
 		t.Fatalf("decoding bad data: expected error got nil")
 	}
 
+	buf = bytes.NewBuffer([]byte("bad data"))
+	_, _, err = DecodeWithFormat(buf)
+	if err == nil {
+		t.Fatalf("decoding bad data: expected error got nil")
+	}
+
 	err = Save(imgWithAlpha, filepath.Join(dir, "test.unknown"))
 	if err != ErrUnsupportedFormat {
 		t.Fatalf("got %v want ErrUnsupportedFormat", err)


### PR DESCRIPTION
The standard go image library provides the **format** return value when calling **Decode**.
The imaging library provided the **FormatFromFilename** to get the format of the image (needed for encoding into desired image format).
Given that for performing image manipulations the image has to be loaded in memory,  the format comes for free when calling **img.Decode**.

I did not modify the **imaging.Decode** functions to not break existing users of this library.