### PR TITLE
Add a FormatFromExtension helper

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -57,14 +57,20 @@ var formatFromExt = map[string]Format{
 	".gif":  GIF,
 }
 
-// FormatFromFilename parses image format from filename extension:
+// FormatFromExtension parses image format from extension:
 // "jpg" (or "jpeg"), "png", "gif", "tif" (or "tiff") and "bmp" are supported.
-func FormatFromFilename(filename string) (Format, error) {
-	ext := strings.ToLower(filepath.Ext(filename))
-	if f, ok := formatFromExt[ext]; ok {
+func FormatFromExtension(ext string) (Format, error) {
+	if f, ok := formatFromExt["."+strings.ToLower(strings.TrimPrefix(ext, "."))]; ok {
 		return f, nil
 	}
 	return -1, ErrUnsupportedFormat
+}
+
+// FormatFromFilename parses image format from filename extension:
+// "jpg" (or "jpeg"), "png", "gif", "tif" (or "tiff") and "bmp" are supported.
+func FormatFromFilename(filename string) (Format, error) {
+	ext := filepath.Ext(filename)
+	return FormatFromExtension(ext)
 }
 
 var (

--- a/helpers.go
+++ b/helpers.go
@@ -48,19 +48,19 @@ func (f Format) String() string {
 }
 
 var formatFromExt = map[string]Format{
-	".jpg":  JPEG,
-	".jpeg": JPEG,
-	".png":  PNG,
-	".tif":  TIFF,
-	".tiff": TIFF,
-	".bmp":  BMP,
-	".gif":  GIF,
+	"jpg":  JPEG,
+	"jpeg": JPEG,
+	"png":  PNG,
+	"tif":  TIFF,
+	"tiff": TIFF,
+	"bmp":  BMP,
+	"gif":  GIF,
 }
 
 // FormatFromExtension parses image format from extension:
 // "jpg" (or "jpeg"), "png", "gif", "tif" (or "tiff") and "bmp" are supported.
 func FormatFromExtension(ext string) (Format, error) {
-	if f, ok := formatFromExt["."+strings.ToLower(strings.TrimPrefix(ext, "."))]; ok {
+	if f, ok := formatFromExt[strings.ToLower(strings.TrimPrefix(ext, "."))]; ok {
 		return f, nil
 	}
 	return -1, ErrUnsupportedFormat

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -502,3 +502,46 @@ func TestClone(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatFromExtension(t *testing.T) {
+	testCases := []struct {
+		name string
+		ext  string
+		want Format
+		err  error
+	}{
+		{
+			name: "jpg without leading dot",
+			ext:  "jpg",
+			want: JPEG,
+		},
+		{
+			name: "jpg with leading dot",
+			ext:  ".jpg",
+			want: JPEG,
+		},
+		{
+			name: "jpg uppercase",
+			ext:  ".JPG",
+			want: JPEG,
+		},
+		{
+			name: "unsupported",
+			ext:  ".unsupportedextension",
+			want: -1,
+			err:  ErrUnsupportedFormat,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := FormatFromExtension(tc.ext)
+			if err != tc.err {
+				t.Errorf("got error %#v want %#v", err, tc.err)
+			}
+			if got != tc.want {
+				t.Errorf("got result %#v want %#v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
closes #77 

I had to add a leading ".", because the `formatFromExt` map has them.