### PR TITLE
Crop before resize in Fill

### DIFF
--- a/resize.go
+++ b/resize.go
@@ -292,14 +292,17 @@ func Fill(img image.Image, width, height int, anchor Anchor, filter ResampleFilt
 	srcAspectRatio := float64(srcW) / float64(srcH)
 	minAspectRatio := float64(minW) / float64(minH)
 
-	var tmp *image.NRGBA
+	var scale float64
 	if srcAspectRatio < minAspectRatio {
-		tmp = Resize(img, minW, 0, filter)
+		scale = float64(srcW) / float64(minW)
 	} else {
-		tmp = Resize(img, 0, minH, filter)
+		scale = float64(srcH) / float64(minH)
 	}
+	cropW := int(float64(minW) * scale)
+	cropH := int(float64(minH) * scale)
+	tmp := CropAnchor(img, cropW, cropH, anchor)
 
-	return CropAnchor(tmp, minW, minH, anchor)
+	return Resize(tmp, minW, minH, filter)
 }
 
 // Thumbnail scales the image up or down using the specified resample filter, crops it

--- a/resize_test.go
+++ b/resize_test.go
@@ -672,3 +672,48 @@ func BenchmarkResize(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkFill(b *testing.B) {
+	for _, dir := range []string{"Vertical", "Horizontal"} {
+		for _, filter := range []string{"NearestNeighbor", "Linear", "CatmullRom", "Lanczos"} {
+			for _, format := range []string{"JPEG", "PNG"} {
+				var width, height int
+				switch dir {
+				case "Vertical":
+					width = 100
+					height = 1000
+				case "Horizontal":
+					width = 1000
+					height = 100
+				}
+
+				var f ResampleFilter
+				switch filter {
+				case "NearestNeighbor":
+					f = NearestNeighbor
+				case "Linear":
+					f = Linear
+				case "CatmullRom":
+					f = CatmullRom
+				case "Lanczos":
+					f = Lanczos
+				}
+
+				var img image.Image
+				switch format {
+				case "JPEG":
+					img = testdataBranchesJPG
+				case "PNG":
+					img = testdataBranchesPNG
+				}
+
+				b.Run(fmt.Sprintf("%s %s %s", dir, filter, format), func(b *testing.B) {
+					b.ReportAllocs()
+					for i := 0; i < b.N; i++ {
+						Fill(img, width, height, Center, f)
+					}
+				})
+			}
+		}
+	}
+}


### PR DESCRIPTION
#83 Crop before resizing in the Fill function for the sake of efficiency.

This breaks one test, `TestFill/Fill_4x4_2x8_Top_Nearest` and I'm afraid I'm not sure why, I'm pretty sure the code is correct as all other tests pass, but maybe there's a strange edge case I'm not thinking of.

I've also added some benchmarks for the Fill function, on my machine I get speedups of around 8x:

Before
---
```
goos: windows
goarch: amd64
pkg: github.com/bspammer/imaging
BenchmarkFill/Vertical_NearestNeighbor_JPEG-8         	     500	   3501987 ns/op	 7393248 B/op	      17 allocs/op
BenchmarkFill/Vertical_NearestNeighbor_PNG-8          	     500	   3370063 ns/op	 7393200 B/op	      17 allocs/op
BenchmarkFill/Vertical_Linear_JPEG-8                  	     100	  10374025 ns/op	 9178134 B/op	      38 allocs/op
BenchmarkFill/Vertical_Linear_PNG-8                   	     100	  10154148 ns/op	 9178224 B/op	      38 allocs/op
BenchmarkFill/Vertical_CatmullRom_JPEG-8              	     100	  13472248 ns/op	 9260050 B/op	      38 allocs/op
BenchmarkFill/Vertical_CatmullRom_PNG-8               	     100	  13222394 ns/op	 9260042 B/op	      38 allocs/op
BenchmarkFill/Vertical_Lanczos_JPEG-8                 	     100	  17240083 ns/op	 9341974 B/op	      38 allocs/op
BenchmarkFill/Vertical_Lanczos_PNG-8                  	     100	  17819746 ns/op	 9341968 B/op	      38 allocs/op
BenchmarkFill/Horizontal_NearestNeighbor_JPEG-8       	    1000	   1852933 ns/op	 4049702 B/op	      17 allocs/op
BenchmarkFill/Horizontal_NearestNeighbor_PNG-8        	    1000	   1690025 ns/op	 4049702 B/op	      17 allocs/op
BenchmarkFill/Horizontal_Linear_JPEG-8                	     300	   5520155 ns/op	 4931467 B/op	      38 allocs/op
BenchmarkFill/Horizontal_Linear_PNG-8                 	     300	   5296951 ns/op	 4931474 B/op	      38 allocs/op
BenchmarkFill/Horizontal_CatmullRom_JPEG-8            	     200	   6946002 ns/op	 4988816 B/op	      38 allocs/op
BenchmarkFill/Horizontal_CatmullRom_PNG-8             	     200	   6746117 ns/op	 4988812 B/op	      38 allocs/op
BenchmarkFill/Horizontal_Lanczos_JPEG-8               	     200	   9024805 ns/op	 5046154 B/op	      38 allocs/op
BenchmarkFill/Horizontal_Lanczos_PNG-8                	     200	   8829919 ns/op	 5046162 B/op	      38 allocs/op
PASS
ok  	github.com/bspammer/imaging	30.481s

```

After
---
```
goos: windows
goarch: amd64
pkg: github.com/bspammer/imaging
BenchmarkFill/Vertical_NearestNeighbor_JPEG-8         	    3000	    404434 ns/op	  479008 B/op	      12 allocs/op
BenchmarkFill/Vertical_NearestNeighbor_PNG-8          	    3000	    411429 ns/op	  479006 B/op	      12 allocs/op
BenchmarkFill/Vertical_Linear_JPEG-8                  	    2000	    877495 ns/op	  790118 B/op	      38 allocs/op
BenchmarkFill/Vertical_Linear_PNG-8                   	    2000	    878994 ns/op	  790120 B/op	      38 allocs/op
BenchmarkFill/Vertical_CatmullRom_JPEG-8              	    2000	   1154835 ns/op	  826726 B/op	      38 allocs/op
BenchmarkFill/Vertical_CatmullRom_PNG-8               	    2000	   1149338 ns/op	  826732 B/op	      38 allocs/op
BenchmarkFill/Vertical_Lanczos_JPEG-8                 	    1000	   1681033 ns/op	  862314 B/op	      38 allocs/op
BenchmarkFill/Vertical_Lanczos_PNG-8                  	    1000	   1723007 ns/op	  862314 B/op	      38 allocs/op
BenchmarkFill/Horizontal_NearestNeighbor_JPEG-8       	    5000	    285236 ns/op	  550748 B/op	      12 allocs/op
BenchmarkFill/Horizontal_NearestNeighbor_PNG-8        	   10000	    240661 ns/op	  550747 B/op	      12 allocs/op
BenchmarkFill/Horizontal_Linear_JPEG-8                	    2000	    969941 ns/op	  963304 B/op	      38 allocs/op
BenchmarkFill/Horizontal_Linear_PNG-8                 	    2000	    925467 ns/op	  963306 B/op	      38 allocs/op
BenchmarkFill/Horizontal_CatmullRom_JPEG-8            	    1000	   1210303 ns/op	  999915 B/op	      38 allocs/op
BenchmarkFill/Horizontal_CatmullRom_PNG-8             	    2000	   1172325 ns/op	  999916 B/op	      38 allocs/op
BenchmarkFill/Horizontal_Lanczos_JPEG-8               	    1000	   1801962 ns/op	 1035500 B/op	      38 allocs/op
BenchmarkFill/Horizontal_Lanczos_PNG-8                	    1000	   1838941 ns/op	 1035501 B/op	      38 allocs/op
PASS
ok  	github.com/bspammer/imaging	30.730s
```
