### PR TITLE
Added DecodeWithFormat

### DIFF
--- a/io_test.go
+++ b/io_test.go
@@ -233,6 +233,37 @@ func TestFormatFromExtension(t *testing.T) {
 	}
 }
 
+func TestDecodeWithFormat(t *testing.T) {
+	testCases := []struct {
+		name string
+		file string
+		want Format
+	}{
+		{
+			name: "JPEG Decode",
+			file: "testdata/branches.jpg",
+			want: JPEG,
+		},
+		{
+			name: "PNG Decode",
+			file: "testdata/branches.png",
+			want: PNG,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := ioutil.ReadFile(tc.file)
+			if err != nil {
+				t.Errorf("got error %#v", err)
+			}
+			_, format, err := DecodeWithFormat(bytes.NewReader(b))
+			if format != tc.want {
+				t.Errorf("got result %#v want %#v", formatNames[format], formatNames[tc.want])
+			}
+		})
+	}
+}
+
 func TestReadOrientation(t *testing.T) {
 	testCases := []struct {
 		path   string


### PR DESCRIPTION
In systems that ignore the file name / extension (either use UUIDs or just don't trust users) it makes sense to read the format straight from the image bytes themselves. `imaging` currently ignores the format while decoding. 

I believe this should be in the library instead of outside because:
1. passing in a reader to `imaging` effectively destroys it, so doing another decode requires a re-read.
2. `imaging` already has a Format enum and conversion maps.
3. `imaging` already imports the TIFF and BMP packages, as well as GIF, PNG, JPEG. it doesn't make sense to ask clients to side-effect import all those packages again to get the proper registrations. 
4. Both `Encode` already takes a `Format` as an argument, it increases both symmetry and likeness to the stdlib for `Decode` to return it. 