### PR TITLE
upgrade x/image dependency to support v4 and v5 bmp info headers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/disintegration/imaging
 
-require golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81
+require golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,3 @@
-golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81 h1:00VmoueYNlNz/aHIilyyQz/MHSqGoWJzpFv/HW8xpzI=
-golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
+golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 h1:hVwzHzIUGRjiF7EcUjqNxk3NCfkPxbDKRdnNE1Rpg0U=
+golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
BITMAPV4HEADER and BITMAPV5HEADER support for image/bmp was introduced in https://go-review.googlesource.com/c/image/+/141799/ and solves the "bmp: unsupported BMP image" errors when trying to open BMP files with such headers: https://github.com/golang/go/issues/27767